### PR TITLE
Support ppc64le

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,30 @@
+docker_image:                                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux")]
+   - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2   # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+   - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2   # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+
+c_compiler_version:        # [linux]
+  - 9                      # [ppc64le]
+  - 9                      # [aarch64]
+
+cxx_compiler_version:      # [linux]
+  - 9                      # [ppc64le]
+  - 9                      # [aarch64]
+
+fortran_compiler_version:  # [linux]
+  - 9                      # [ppc64le]
+  - 9                      # [aarch64]
+
+cuda_compiler:
+  - nvcc
+
+cuda_compiler_version:
+  - 11.2                   # [ppc64le]
+  - 11.2                   # [aarch64]
+
+cudnn:
+  - undefined              # [ppc64le]
+  - undefined              # [aarch64]
+
+cdt_name:  # [linux]
+  - cos7   # [ppc64le]
+  - cos7   # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - setup.py.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   skip: true  # [cuda_compiler_version == "None"]
   skip: true  # [cuda_compiler_version == "10.2"]


### PR DESCRIPTION
Adding ppc64le support . The ptxcompiler requires cuda 11.1+.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
