### PR TITLE
Don't require Numba to run

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d1b8783a832a36ca5ae5c3623e6730a69a44a72c249e21537ffcfce4511c9c1a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None")]
   ignore_run_exports_from:
     - {{ compiler("cuda") }}
@@ -28,10 +28,10 @@ requirements:
     - cudatoolkit {{ cuda_compiler_version }}
   run:
     - python
-    - numba >=0.54
     - cudatoolkit >={{ cuda_major ~ ".0" }},<={{ cuda_compiler_version }}
   run_constrained:
     - __cuda >={{ cuda_major ~ ".0" }}
+    - numba >=0.54
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Having Numba in the `run` section of the recipe forces Numba to be installed with ptxcompiler. Although ptxcompiler can patch Numba to use it, Numba isn't required for ptxcompiler to be used itself. Additionally, having ptxcompiler depend on Numba makes it hard to use ptxcompiler from Numba (e.g. for https://github.com/numba/numba/pull/8180).

This PR moves it to `run_constrained`, so that its installation is not required, but if it is present then only versions that can be correctly patched to use ptxcompiler are allowed.
